### PR TITLE
[TDO] Update PHP SDK version to add firewall header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php" : "^7.1",
 		"aws/aws-sdk-php": "^3.0",
 		"ramsey/uuid": "^3.0.0",
-		"serato/sws-php-sdk": "^2.0.0"
+		"serato/sws-php-sdk": "^2.1.4"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Increase the PHP SDK version to ensure that the X-Serato-Firewall header is added to requests, allowing them to bypass the firewall.