### PR TITLE
[Web 7443] Remove old rows from `client.app.sso.auth.requests` DynamoDB table

### DIFF
--- a/src/AuthRequestDynamoDbStorage.php
+++ b/src/AuthRequestDynamoDbStorage.php
@@ -204,7 +204,7 @@ class AuthRequestDynamoDbStorage implements AuthRequestStorageInterface
             'client_app_id' => ['S' => $this->data['client_app_id']],
             'uri'           => ['S' => $this->data['uri']],
             'created_at'    => ['N' => (string)$this->data['created_at']->getTimestamp()],
-            'ttl'           => ['N' => (string)(time() + self::ITEM_TIME_TO_LIVE)]
+            'ttl'           => ['N' => (string)($this->data['created_at'] + self::ITEM_TIME_TO_LIVE)]
         ];
     }
 

--- a/src/AuthRequestDynamoDbStorage.php
+++ b/src/AuthRequestDynamoDbStorage.php
@@ -24,7 +24,7 @@ class AuthRequestDynamoDbStorage implements AuthRequestStorageInterface
 
     private const DYNAMO_DB_TABLE_NAME = 'client.app.sso.auth.requests';
 
-    private const ITEM_TIME_TO_LIVE = 43200; # 12 hours
+    private const ITEM_TIME_TO_LIVE = 7200; # 120 mins
 
     public function __construct(AwsSdk $awsSdk)
     {

--- a/src/AuthRequestDynamoDbStorage.php
+++ b/src/AuthRequestDynamoDbStorage.php
@@ -24,6 +24,8 @@ class AuthRequestDynamoDbStorage implements AuthRequestStorageInterface
 
     private const DYNAMO_DB_TABLE_NAME = 'client.app.sso.auth.requests';
 
+    private const ITEM_TIME_TO_LIVE = 43200; # 12 hours
+
     public function __construct(AwsSdk $awsSdk)
     {
         $this->awsSdk = $awsSdk;
@@ -201,7 +203,8 @@ class AuthRequestDynamoDbStorage implements AuthRequestStorageInterface
             'id'            => ['S' => $this->data['id']],
             'client_app_id' => ['S' => $this->data['client_app_id']],
             'uri'           => ['S' => $this->data['uri']],
-            'created_at'    => ['N' => (string)$this->data['created_at']->getTimestamp()]
+            'created_at'    => ['N' => (string)$this->data['created_at']->getTimestamp()],
+            'ttl'           => ['N' => (string)(time() + self::ITEM_TIME_TO_LIVE)]
         ];
     }
 

--- a/src/AuthRequestDynamoDbStorage.php
+++ b/src/AuthRequestDynamoDbStorage.php
@@ -204,7 +204,7 @@ class AuthRequestDynamoDbStorage implements AuthRequestStorageInterface
             'client_app_id' => ['S' => $this->data['client_app_id']],
             'uri'           => ['S' => $this->data['uri']],
             'created_at'    => ['N' => (string)$this->data['created_at']->getTimestamp()],
-            'ttl'           => ['N' => (string)($this->data['created_at'] + self::ITEM_TIME_TO_LIVE)]
+            'ttl'           => ['N' => (string)($this->data['created_at']->getTimestamp() + self::ITEM_TIME_TO_LIVE)]
         ];
     }
 

--- a/src/Exception/AuthRequestExpiredException.php
+++ b/src/Exception/AuthRequestExpiredException.php
@@ -8,5 +8,4 @@ use RuntimeException;
 
 class AuthRequestExpiredException extends RuntimeException
 {
-
 }

--- a/src/Exception/InvalidAuthRequestIdException.php
+++ b/src/Exception/InvalidAuthRequestIdException.php
@@ -8,5 +8,4 @@ use RuntimeException;
 
 class InvalidAuthRequestIdException extends RuntimeException
 {
-
 }

--- a/src/Exception/TokenExchangeException.php
+++ b/src/Exception/TokenExchangeException.php
@@ -8,5 +8,4 @@ use RuntimeException;
 
 class TokenExchangeException extends RuntimeException
 {
-
 }


### PR DESCRIPTION
- The client.app.sso.auth.requests DynamoDB table is configured with a TTL that automatically removes rows of data that are 120 mins old.